### PR TITLE
Allocate tags to people, refs: #22

### DIFF
--- a/db/seeds/support/data_migrator.rb
+++ b/db/seeds/support/data_migrator.rb
@@ -116,6 +116,10 @@ class DataMigrator
                      address: row[:address])
     end
 
+    def retrieve_boolean(value)
+      value == "t"
+    end
+
     private
 
     def section_from_row(row)

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -47,6 +47,7 @@ file 'db/seeds/production/people.csv' => 'db/seeds/production' do |task|
     biz_contact.createdon AS recruited_at,
     biz_contact.title,
     biz_contact.deathdate AS died_at,
+    biz_contact.ismember AS is_member,
     biz_bankpost.iban AS iban,
     biz_contact.textfield1 AS occupation,
     biz_contact.mobile AS mobile_phone_number,


### PR DESCRIPTION
Noch offene Fragen:
- Was geschieht bei Personen welche nicht Mitglied sind und nicht in der Datenbank vorhanden sind? Aktuell werden diese mit einer info auf der Konsole geskipped.
- In der momentanen Version wird ein separates csv, für die Personen welche nicht Mitglieder sind erstellt (das non_members.csv). Diese werden dann beim Import auf die Personen in der DB gemapped und dementsprechend mit dem Tag 'Nicht Mitlied im Dachverband' getagged. Ist das in Ordnung so? Denn soweit ich verstehe, können die Aktualisierungen dann idempotent durchgeführt werden.