### PR TITLE
translate nickname to "function"

### DIFF
--- a/config/locales/models.svse.de.yml
+++ b/config/locales/models.svse.de.yml
@@ -133,6 +133,7 @@ de:
         died_at: Verstorben am
         iban: IBAN
         occupation: Beruf
+        nickname: Funktion
         recruited_at: Geworben am
         recruited_by: Geworben durch
         recruited_by_id: Geworben durch


### PR DESCRIPTION
Beim SVSE wird der Nickname für "Funktion" misbraucht. Dies ist mit dem Kunden so besprochen, und dem Kunden ist bewusst, dass dies ein nicht ganz schöner Workaround ist.