### PR TITLE
Cleanup collection select calls 🤖

### DIFF
--- a/app/views/people/_fields_svse.html.haml
+++ b/app/views/people/_fields_svse.html.haml
@@ -16,6 +16,5 @@
                                   Person::STATES.map {|state| [state, Person.state_labels[state.to_sym]]},
                                   :first,
                                   :last,
-                                  { prompt: true },
-                                  class: 'form-select form-select-sm')
+                                  { prompt: true })
   = f.labeled_input_fields(:died_at)


### PR DESCRIPTION
Remove now-redundant class: 'form-select form-select-sm' defaults from
collection_select/labeled_collection_select calls, now that
StandardFormBuilder#collection_select applies this class by default.
